### PR TITLE
feat: Ajout du block layout ChaoticumSeminarioConferences pour visual…

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -50,6 +50,7 @@ return [
         'invokables' => [
             'chaoticumSeminario' => Site\BlockLayout\ChaoticumSeminario::class,
             'chaoticumSeminarioExplore' => Site\BlockLayout\ChaoticumSeminarioExplore::class,
+            'chaoticumSeminarioConferences' => Site\BlockLayout\ChaoticumSeminarioConferences::class,
         ],
     ],
     'form_elements' => [
@@ -58,6 +59,7 @@ return [
             Form\ConfigForm::class => Form\ConfigForm::class,
             Form\ChaoticumSeminarioFieldset::class => Form\ChaoticumSeminarioFieldset::class,
             Form\ChaoticumSeminarioExploreFieldset::class => Form\ChaoticumSeminarioExploreFieldset::class,
+            Form\ChaoticumSeminarioConferencesFieldset::class => Form\ChaoticumSeminarioConferencesFieldset::class,
         ],
         'factories' => [
             'ChaoticumSeminario\Form\Element\BatchEditSemafor' => Service\Form\Element\BatchEditSemaforFactory::class,
@@ -107,6 +109,13 @@ return [
             'chaoticumSeminarioExplore' => [
                 'heading' => '',
                 'item_id' => null,
+            ],
+            'chaoticumSeminarioConferences' => [
+                'heading' => '',
+                'item_set_id' => null,
+                'conference_template' => 'Cours',
+                'transcription_template' => 'Transcription',
+                'per_page' => 10,
             ],
         ],
     ],

--- a/src/Form/ChaoticumSeminarioConferencesFieldset.php
+++ b/src/Form/ChaoticumSeminarioConferencesFieldset.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace ChaoticumSeminario\Form;
+
+use Laminas\Form\Element;
+use Laminas\Form\Fieldset;
+
+class ChaoticumSeminarioConferencesFieldset extends Fieldset
+{
+    public function init(): void
+    {
+        $this
+            ->add([
+                'name' => 'o:block[__blockIndex__][o:data][heading]',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Block title', // @translate
+                    'info' => 'Heading for the block, if any.', // @translate
+                ],
+            ])
+            ->add([
+                'name' => 'o:block[__blockIndex__][o:data][item_set_id]',
+                'type' => Element\Number::class,
+                'options' => [
+                    'label' => 'Item set id', // @translate
+                    'info' => 'Filter conferences by item set (optional).', // @translate
+                ],
+            ])
+            ->add([
+                'name' => 'o:block[__blockIndex__][o:data][conference_template]',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Conference resource template', // @translate
+                    'info' => 'Label of the resource template for conferences (e.g. "Cours").', // @translate
+                ],
+                'attributes' => [
+                    'placeholder' => 'Cours',
+                ],
+            ])
+            ->add([
+                'name' => 'o:block[__blockIndex__][o:data][transcription_template]',
+                'type' => Element\Text::class,
+                'options' => [
+                    'label' => 'Transcription resource template', // @translate
+                    'info' => 'Label of the resource template for transcriptions (e.g. "Transcription").', // @translate
+                ],
+                'attributes' => [
+                    'placeholder' => 'Transcription',
+                ],
+            ])
+            ->add([
+                'name' => 'o:block[__blockIndex__][o:data][per_page]',
+                'type' => Element\Number::class,
+                'options' => [
+                    'label' => 'Conferences per page', // @translate
+                ],
+                'attributes' => [
+                    'value' => 10,
+                    'min' => 1,
+                    'max' => 100,
+                ],
+            ]);
+    }
+}

--- a/src/Site/BlockLayout/ChaoticumSeminarioConferences.php
+++ b/src/Site/BlockLayout/ChaoticumSeminarioConferences.php
@@ -1,0 +1,115 @@
+<?php declare(strict_types=1);
+
+namespace ChaoticumSeminario\Site\BlockLayout;
+
+use Laminas\View\Renderer\PhpRenderer;
+use Omeka\Api\Representation\SitePageBlockRepresentation;
+use Omeka\Api\Representation\SitePageRepresentation;
+use Omeka\Api\Representation\SiteRepresentation;
+use Omeka\Site\BlockLayout\AbstractBlockLayout;
+
+class ChaoticumSeminarioConferences extends AbstractBlockLayout
+{
+    const PARTIAL_NAME = 'common/block-layout/chaoticum-seminario-conferences';
+
+    public function getLabel()
+    {
+        return 'Chaoticum Seminario Conferences'; // @translate
+    }
+
+    public function form(
+        PhpRenderer $view,
+        SiteRepresentation $site,
+        SitePageRepresentation $page = null,
+        SitePageBlockRepresentation $block = null
+    ) {
+        $services = $site->getServiceLocator();
+        $formElementManager = $services->get('FormElementManager');
+        $defaultSettings = $services->get('Config')['chaoticumseminario']['block_settings']['chaoticumSeminarioConferences'];
+        $blockFieldset = \ChaoticumSeminario\Form\ChaoticumSeminarioConferencesFieldset::class;
+
+        $data = $block ? $block->data() + $defaultSettings : $defaultSettings;
+
+        $dataForm = [];
+        foreach ($data as $key => $value) {
+            $dataForm['o:block[__blockIndex__][o:data][' . $key . ']'] = $value;
+        }
+
+        $fieldset = $formElementManager->get($blockFieldset);
+        $fieldset->populateValues($dataForm);
+
+        return $view->formCollection($fieldset, false);
+    }
+
+    public function render(PhpRenderer $view, SitePageBlockRepresentation $block)
+    {
+        $api = $view->api();
+
+        $conferenceTemplate = $block->dataValue('conference_template', 'Cours');
+        $transcriptionTemplate = $block->dataValue('transcription_template', 'Transcription');
+        $itemSetId = (int) $block->dataValue('item_set_id', 0);
+        $perPage = (int) $block->dataValue('per_page', 10);
+
+        $query = ['resource_template_label' => $conferenceTemplate, 'sort_by' => 'dcterms:valid', 'sort_order' => 'desc'];
+        if ($itemSetId) {
+            $query['item_set_id'] = $itemSetId;
+        }
+
+        try {
+            $response = $api->search('items', $query + ['per_page' => $perPage]);
+            $conferences = $response->getContent();
+            $totalConferences = $response->getTotalResults();
+        } catch (\Exception $e) {
+            $conferences = [];
+            $totalConferences = 0;
+        }
+
+        $conferenceData = [];
+        foreach ($conferences as $conference) {
+            $transcriptions = [];
+            try {
+                $transResponse = $api->search('items', [
+                    'resource_template_label' => $transcriptionTemplate,
+                    'property' => [[
+                        'joiner' => 'and',
+                        'property' => 'dcterms:isReferencedBy',
+                        'type' => 'res',
+                        'text' => $conference->id(),
+                    ]],
+                ]);
+                $transcriptions = $transResponse->getContent();
+            } catch (\Exception $e) {
+                $transcriptions = [];
+            }
+
+            $conferenceData[] = [
+                'item' => $conference,
+                'transcriptions' => $transcriptions,
+            ];
+        }
+
+        $vars = [
+            'block' => $block,
+            'heading' => $block->dataValue('heading', ''),
+            'conferenceData' => $conferenceData,
+            'totalConferences' => $totalConferences,
+        ];
+        return $view->partial(self::PARTIAL_NAME, $vars);
+    }
+
+    public function getFulltextText(PhpRenderer $view, SitePageBlockRepresentation $block)
+    {
+        return strip_tags($this->render($view, $block));
+    }
+
+    public function prepareRender(PhpRenderer $view): void
+    {
+        $assetUrl = $view->plugin('assetUrl');
+        $view->headScript()
+            ->appendFile($assetUrl('js/bootstrap5.3.bundle.min.js', 'ChaoticumSeminario'));
+        $view->headLink()
+            ->prependStylesheet($assetUrl('css/main.css', 'ChaoticumSeminario'))
+            ->prependStylesheet($assetUrl('css/bootstrap5.3.min.css', 'ChaoticumSeminario'))
+            ->prependStylesheet($assetUrl('css/all.min.css', 'ChaoticumSeminario'));
+    }
+}

--- a/view/common/block-layout/chaoticum-seminario-conferences.phtml
+++ b/view/common/block-layout/chaoticum-seminario-conferences.phtml
@@ -1,0 +1,147 @@
+<?php
+/**
+ * @var \Laminas\View\Renderer\PhpRenderer $this
+ * @var \Omeka\Api\Representation\SitePageBlockRepresentation $block
+ * @var string $heading
+ * @var array $conferenceData  Each entry: ['item' => ItemRepresentation, 'transcriptions' => ItemRepresentation[]]
+ * @var int $totalConferences
+ */
+?>
+
+<?php if ($heading): ?>
+<h2><?php echo $this->escapeHtml($heading); ?></h2>
+<?php endif; ?>
+
+<?php if (empty($conferenceData)): ?>
+<p class="alert alert-info"><?php echo $this->translate('No conferences found.'); ?></p>
+<?php else: ?>
+
+<div class="cs-conferences-block">
+    <div class="cs-conferences-header mb-3 d-flex justify-content-between align-items-center">
+        <span class="text-muted small">
+            <?php echo sprintf($this->translate('%d conference(s)'), $totalConferences); ?>
+        </span>
+        <input type="search" id="cs-conf-search" class="form-control form-control-sm w-auto"
+               placeholder="<?php echo $this->escapeHtmlAttr($this->translate('Search conferences…')); ?>">
+    </div>
+
+    <div class="accordion" id="cs-conferences-accordion">
+        <?php foreach ($conferenceData as $index => $entry): ?>
+            <?php
+            /** @var \Omeka\Api\Representation\ItemRepresentation $conference */
+            $conference = $entry['item'];
+            $transcriptions = $entry['transcriptions'];
+            $collapseId = 'cs-conf-collapse-' . $conference->id();
+            $headingId  = 'cs-conf-heading-' . $conference->id();
+
+            $title = $conference->displayTitle();
+            $date  = $conference->value('dcterms:valid') ?? $conference->value('dcterms:date');
+            $theme = $conference->value('curation:theme');
+            $number = $conference->value('curation:number');
+            $description = $conference->value('dcterms:description');
+            ?>
+            <div class="accordion-item cs-conference-item" data-title="<?php echo $this->escapeHtmlAttr(strtolower($title)); ?>">
+                <h2 class="accordion-header" id="<?php echo $headingId; ?>">
+                    <button class="accordion-button collapsed" type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#<?php echo $collapseId; ?>"
+                            aria-expanded="false"
+                            aria-controls="<?php echo $collapseId; ?>">
+                        <span class="cs-conf-title flex-grow-1">
+                            <?php if ($number): ?>
+                                <span class="badge bg-secondary me-2"><?php echo $this->escapeHtml($number->asHtml()); ?></span>
+                            <?php endif; ?>
+                            <?php echo $this->escapeHtml($title); ?>
+                        </span>
+                        <span class="ms-3 d-flex gap-2 align-items-center">
+                            <?php if ($date): ?>
+                                <span class="badge bg-light text-dark"><?php echo $this->escapeHtml($date->asHtml()); ?></span>
+                            <?php endif; ?>
+                            <?php if ($theme): ?>
+                                <span class="badge bg-primary"><?php echo $this->escapeHtml($theme->asHtml()); ?></span>
+                            <?php endif; ?>
+                            <span class="badge bg-info text-dark">
+                                <?php echo count($transcriptions); ?> <?php echo $this->translate('transcription(s)'); ?>
+                            </span>
+                        </span>
+                    </button>
+                </h2>
+                <div id="<?php echo $collapseId; ?>" class="accordion-collapse collapse"
+                     aria-labelledby="<?php echo $headingId; ?>"
+                     data-bs-parent="#cs-conferences-accordion">
+                    <div class="accordion-body">
+                        <?php if ($description): ?>
+                            <p class="text-muted mb-3"><?php echo $this->escapeHtml($description->asHtml()); ?></p>
+                        <?php endif; ?>
+
+                        <div class="d-flex justify-content-end mb-2">
+                            <a href="<?php echo $conference->siteUrl(); ?>" class="btn btn-sm btn-outline-primary">
+                                <i class="fas fa-external-link-alt me-1"></i><?php echo $this->translate('View conference'); ?>
+                            </a>
+                        </div>
+
+                        <?php if (empty($transcriptions)): ?>
+                            <p class="text-muted fst-italic"><?php echo $this->translate('No transcriptions available.'); ?></p>
+                        <?php else: ?>
+                            <div class="cs-transcriptions-list">
+                                <h6 class="text-uppercase text-muted small mb-2">
+                                    <i class="fas fa-file-alt me-1"></i><?php echo $this->translate('Transcriptions'); ?>
+                                </h6>
+                                <div class="list-group list-group-flush">
+                                    <?php foreach ($transcriptions as $transcription): ?>
+                                        <?php
+                                        $transTitle = $transcription->displayTitle();
+                                        $transDesc  = $transcription->value('dcterms:description');
+                                        $transData  = $transcription->value('curation:data');
+                                        ?>
+                                        <div class="list-group-item list-group-item-action px-0">
+                                            <div class="d-flex w-100 justify-content-between align-items-start">
+                                                <div class="flex-grow-1">
+                                                    <h6 class="mb-1">
+                                                        <a href="<?php echo $transcription->siteUrl(); ?>">
+                                                            <?php echo $this->escapeHtml($transTitle); ?>
+                                                        </a>
+                                                    </h6>
+                                                    <?php if ($transDesc): ?>
+                                                        <p class="mb-1 small text-muted">
+                                                            <?php echo $this->escapeHtml(mb_strimwidth($transDesc->asHtml(), 0, 200, '…')); ?>
+                                                        </p>
+                                                    <?php endif; ?>
+                                                </div>
+                                                <div class="ms-3 d-flex flex-column align-items-end gap-1">
+                                                    <?php foreach ($transcription->media() as $media): ?>
+                                                        <a href="<?php echo $media->originalUrl(); ?>"
+                                                           class="btn btn-xs btn-outline-secondary"
+                                                           title="<?php echo $this->escapeHtmlAttr($media->displayTitle()); ?>">
+                                                            <i class="fas fa-download me-1"></i><?php echo $this->escapeHtml($media->mediaType()); ?>
+                                                        </a>
+                                                    <?php endforeach; ?>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    <?php endforeach; ?>
+                                </div>
+                            </div>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+</div>
+
+<script>
+(function () {
+    const searchInput = document.getElementById('cs-conf-search');
+    if (!searchInput) return;
+    searchInput.addEventListener('input', function () {
+        const q = this.value.toLowerCase().trim();
+        document.querySelectorAll('.cs-conference-item').forEach(function (el) {
+            const title = el.dataset.title || '';
+            el.style.display = (!q || title.includes(q)) ? '' : 'none';
+        });
+    });
+})();
+</script>
+
+<?php endif; ?>


### PR DESCRIPTION
…iser les conférences et leurs transcriptions

- Nouveau bloc Omeka-S affichant les conférences (template "Cours") en accordion Bootstrap 5
- Chaque conférence affiche titre, date, thème, numéro et liste ses transcriptions associées (via dcterms:isReferencedBy)
- Recherche live côté client pour filtrer les conférences par titre
- Formulaire de configuration : heading, item set, templates de ressources, nombre par page
- Enregistrement dans module.config.php (block_layouts, form_elements, block_settings)